### PR TITLE
🐛 Fix `Manifest.resolve_ref() missing 1 required positional argument`

### DIFF
--- a/src/dbt_core_interface/project.py
+++ b/src/dbt_core_interface/project.py
@@ -621,6 +621,7 @@ class DbtProject:
             self.manifest.resolve_ref(
                 target_model_name=target_model_name,
                 target_model_package=None,
+                target_model_version=None,
                 current_project=self.config.project_name,
                 node_package=self.config.project_name,
             ),


### PR DESCRIPTION
Fix `Manifest.resolve_ref() missing 1 required positional argument: 'target_model_version'` (dbt 1.5 compatibility issue).

Might be required to alter behavior based on dbt minor version, since its minor versions are backwards incompatible (it's confusing since they appear to be using SemVer, but they're actually not). See https://github.com/AltimateAI/vscode-dbt-power-user/blob/623b52f2210d5b7964d89c9205c2de158181f1b2/dbt_integration.py#L377-L401 for implementation.